### PR TITLE
Improve (speedup) implementation of succ/pred function.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for wide-word
 
+## 0.1.0.8  -- 2018-12-22
+
+* Improve implementation of succ/pred.
+
 ## 0.1.0.7  -- 2018-11-16
 
 * Switch to Hedgehog for testing.

--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -172,19 +172,19 @@ compare128 (Int128 a1 a0) (Int128 b1 b0) =
 
 succ128 :: Int128 -> Int128
 succ128 (Int128 a1 a0)
-  | a1 == 0x7fffffffffffffff && a0 == maxBound = succError "Int128"
-  | otherwise =
-      case a0 + 1 of
-        0 -> Int128 (a1 + 1) 0
-        s -> Int128 a1 s
+  | a0 == maxBound = if a1 == 0x7fffffffffffffff
+                     then succError "Int128"
+                     else Int128 (a1 + 1) 0
+  | otherwise = Int128 a1 (a0 + 1)
+
 
 pred128 :: Int128 -> Int128
 pred128 (Int128 a1 a0)
-  | a1 == 0x8000000000000000 && a0 == 0 = predError "Int128"
-  | otherwise =
-      case a0 of
-        0 -> Int128 (a1 - 1) maxBound
-        _ -> Int128 a1 (a0 - 1)
+  | a0 == 0 = if a1 == 0x8000000000000000
+              then predError "Int128"
+              else Int128 (a1 - 1) maxBound
+  | otherwise = Int128 a1 (a0 - 1)
+
 
 {-# INLINABLE toEnum128 #-}
 toEnum128 :: Int -> Int128
@@ -395,7 +395,7 @@ toInteger128 i@(Int128 a1 a0)
         Int128 n1 n0 -> negate (fromIntegral n1 `shiftL` 64 + fromIntegral n0)
 
 -- -----------------------------------------------------------------------------
--- Functions for `Integral` instance.
+-- Functions for `Storable` instance.
 
 peek128 :: Ptr Int128 -> IO Int128
 peek128 ptr =

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -150,7 +150,7 @@ instance NFData Word128 where
 
 {-# RULES
 "fromIntegral :: Int -> Word128"     fromIntegral = \(I# i#) -> Word128 (W64# 0##) (W64# (int2Word# i#))
-"fromIntegral :: Word- > Word128"    fromIntegral = Word128 0 . fromIntegral
+"fromIntegral :: Word -> Word128"    fromIntegral = Word128 0 . fromIntegral
 "fromIntegral :: Word32 -> Word128"  fromIntegral = Word128 0 . fromIntegral
 "fromIntegral :: Word64 -> Word128"  fromIntegral = Word128 0
 
@@ -175,19 +175,19 @@ compare128 (Word128 a1 a0) (Word128 b1 b0) =
 
 succ128 :: Word128 -> Word128
 succ128 (Word128 a1 a0)
-  | a1 == maxBound && a0 == maxBound = succError "Word128"
-  | otherwise =
-      case a0 + 1 of
-        0 -> Word128 (a1 + 1) 0
-        s -> Word128 a1 s
+  | a0 == maxBound = if a1 == maxBound
+                     then succError "Word128"
+                     else Word128 (a1 + 1) 0
+  | otherwise = Word128 a1 (a0 + 1)
+
 
 pred128 :: Word128 -> Word128
 pred128 (Word128 a1 a0)
-  | a1 == 0 && a0 == 0 = predError "Word128"
-  | otherwise =
-      case a0 of
-        0 -> Word128 (a1 - 1) maxBound
-        _ -> Word128 a1 (a0 - 1)
+  | a0 == 0 = if a1 == 0
+              then predError "Word128"
+              else Word128 (a1 - 1) maxBound
+  | otherwise = Word128 a1 (a0 - 1)
+
 
 {-# INLINABLE toEnum128 #-}
 toEnum128 :: Int -> Word128
@@ -414,7 +414,7 @@ toInteger128 :: Word128 -> Integer
 toInteger128 (Word128 a1 a0) = fromIntegral a1 `shiftL` 64 + fromIntegral a0
 
 -- -----------------------------------------------------------------------------
--- Functions for `Integral` instance.
+-- Functions for `Storable` instance.
 
 peek128 :: Ptr Word128 -> IO Word128
 peek128 ptr =

--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                wide-word
-version:             0.1.0.7
+version:             0.1.0.8
 synopsis:            Data types for large but fixed width signed and unsigned integers
 description:
   A library to provide data types for large (ie > 64 bits) but fixed width signed


### PR DESCRIPTION
Adjustments to the `succ`/`pred` functions aren't that significant, but they do result in one less `case` statement each in the core and fewer assembler instructions .