### PR TITLE
test all typeclass laws for Word128 and Int128

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 *.o
 .cabal-sandbox/
 cabal.sandbox.config
-dist/
-
+dist*
+.ghc*

--- a/test/laws.hs
+++ b/test/laws.hs
@@ -1,0 +1,59 @@
+import Data.WideWord
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Classes
+import Data.Semiring hiding ((+),(*))
+import Data.Proxy (Proxy(Proxy))
+import Data.Bits
+import Foreign.Storable
+
+main :: IO ()
+main = lawsCheckMany allPropsApplied
+
+allPropsApplied :: [(String, [Laws])]
+allPropsApplied =
+  [ ("Int128", allLaws (Proxy :: Proxy Int128))
+  , ("Word128", allLaws (Proxy :: Proxy Word128))
+  ] 
+
+allLaws ::
+  ( Arbitrary a
+  , Bounded a
+  , Enum a
+  , Eq a
+  , Integral a
+  , Ord a
+  , Read a
+  , Show a
+  , Storable a
+  , Bits a
+  , FiniteBits a
+  , Semiring a
+  ) => Proxy a -> [Laws]
+allLaws p = map ($ p)
+  [ bitsLaws
+  , boundedEnumLaws
+  , eqLaws
+  , integralLaws
+  , ordLaws
+  , semiringLaws
+  , storableLaws
+  ]
+
+instance Arbitrary Word128 where
+  arbitrary = Word128 <$> arbitrary <*> arbitrary
+
+instance Arbitrary Int128 where
+  arbitrary = Int128 <$> arbitrary <*> arbitrary
+
+-- These are used to make sure that 'Num' behaves properly.
+instance Semiring Word128 where
+  zero = 0
+  one  = 1
+  plus = (+)
+  times = (*)
+
+instance Semiring Int128 where
+  zero = 0
+  one  = 1
+  plus = (+)
+  times = (*)

--- a/test/laws.hs
+++ b/test/laws.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 import Data.WideWord
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Classes

--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -56,3 +56,17 @@ test-suite test
                      , ghc-prim
                      , hedgehog                      == 0.6.*
                      , wide-word
+
+test-suite laws
+  default-language:  Haskell2010
+  ghc-options:       -Wall
+  type:              exitcode-stdio-1.0
+
+  main-is:           laws.hs
+  hs-source-dirs:    test
+
+  build-depends:       base                          >= 4.8         && < 5.0
+                     , QuickCheck                    >= 2.9.2       && < 2.13
+                     , quickcheck-classes            >= 0.4.0       && < 0.7.0
+                     , semirings                     >= 0.2         && < 0.3
+                     , wide-word


### PR DESCRIPTION
quickcheck-classes is a library that allows one to test laws of common typeclasses with a minimal api overhead. since wide-word has a lot of non-derived instances, i think it's a good idea to make sure that the typeclass laws are checked.

A lot of the test suite is testing bits/finitebits/storable stuff; this will do that for you automatically, with less code, and will let you only need to add 1 line for each new type (eg Word256/Int256)