### PR TITLE
Fix rewrite rules for Word128. Reinstate fixed rewrite rules for Int128

### DIFF
--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -46,7 +46,7 @@ import GHC.Base (Int (..), and#, int2Word#, minusWord#, not#, or#, plusWord#, pl
 import GHC.Enum (predError, succError)
 import GHC.Int (Int64 (..))
 import GHC.Real ((%))
-import GHC.Word (Word64 (..), byteSwap64)
+import GHC.Word (Word64 (..), Word32, byteSwap64)
 
 
 data Int128 = Int128
@@ -152,6 +152,10 @@ instance NFData Int128 where
 "fromIntegral :: Int128 -> Int128" fromIntegral = id :: Int128 -> Int128
 "fromIntegral :: Word128 -> Int128" fromIntegral = \(Word128 a1 a0) -> Int128 a1 a0
 "fromIntegral :: Int128 -> Word128" fromIntegral = \(Int128 a1 a0) -> Word128 a1 a0
+
+"fromIntegral :: Word -> Int128"    fromIntegral = Int128 0 . (fromIntegral :: Word -> Word64)
+"fromIntegral :: Word32 -> Int128"  fromIntegral = Int128 0 . (fromIntegral :: Word32 -> Word64)
+"fromIntegral :: Word64 -> Int128"  fromIntegral = Int128 0
   #-}
 
 -- -----------------------------------------------------------------------------

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -40,7 +40,8 @@ import GHC.Base (Int (..), and#, int2Word#, minusWord#, not#, or#, plusWord#, pl
                 , quotRemWord2#, subWordC#, timesWord#, timesWord2#, xor#)
 import GHC.Enum (predError, succError)
 import GHC.Real ((%), divZeroError)
-import GHC.Word (Word64 (..), byteSwap64)
+import GHC.Word (Word64 (..), Word32, byteSwap64)
+
 
 import Numeric (showHex)
 
@@ -146,17 +147,15 @@ instance NFData Word128 where
 
 {-# RULES
 "fromIntegral :: Word128 -> Word128" fromIntegral = id :: Word128 -> Word128
-  #-}
 
-{-# RULES
 "fromIntegral :: Int -> Word128"     fromIntegral = \(I# i#) -> Word128 (W64# 0##) (W64# (int2Word# i#))
-"fromIntegral :: Word -> Word128"    fromIntegral = Word128 0 . fromIntegral
-"fromIntegral :: Word32 -> Word128"  fromIntegral = Word128 0 . fromIntegral
+"fromIntegral :: Word -> Word128"    fromIntegral = Word128 0 . (fromIntegral :: Word -> Word64)
+"fromIntegral :: Word32 -> Word128"  fromIntegral = Word128 0 . (fromIntegral :: Word32 -> Word64)
 "fromIntegral :: Word64 -> Word128"  fromIntegral = Word128 0
 
-"fromIntegral :: Word128 -> Int"     fromIntegral = \(Word128 _ w) -> fromIntegral w
-"fromIntegral :: Word128 -> Word"    fromIntegral = \(Word128 _ w) -> fromIntegral w
-"fromIntegral :: Word128 -> Word32"  fromIntegral = \(Word128 _ w) -> fromIntegral w
+"fromIntegral :: Word128 -> Int"     fromIntegral = \(Word128 _ w) -> fromIntegral w :: Int
+"fromIntegral :: Word128 -> Word"    fromIntegral = \(Word128 _ w) -> fromIntegral w :: Word
+"fromIntegral :: Word128 -> Word32"  fromIntegral = \(Word128 _ w) -> fromIntegral w :: Word32
 "fromIntegral :: Word128 -> Word64"  fromIntegral = \(Word128 _ w) -> w
   #-}
 


### PR DESCRIPTION
Without a type signature in rewrite rules they become unreliable. Added type signatures on `fromIntegral`.

Added back rewrite rules for `Int128` that are actually safe, since conversion of `Word8`-`Word64` into `Int128` causes neither loss of precision nor overflows. 