### PR TITLE
Fix Prim instance for Int128.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for wide-word
 
+## 0.1.0.9 -- 2019-02-06
+
+* Fix `Prim` instance for `Int128`
+
 ## 0.1.0.8  -- 2019-01-31
 
 * Improve implementation of succ/pred.

--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -429,8 +429,9 @@ peek128 ptr =
 
 peekElemOff128 :: Ptr Int128 -> Int -> IO Int128
 peekElemOff128 ptr idx =
-  Int128 <$> peekElemOff (castPtr ptr) (2 * idx + index1)
-            <*> peekElemOff (castPtr ptr) (2 * idx + index0)
+  Int128 <$> peekElemOff (castPtr ptr) (idx2 + index1)
+            <*> peekElemOff (castPtr ptr) (idx2 + index0)
+  where idx2 = 2 * idx
 
 poke128 :: Ptr Int128 -> Int128 -> IO ()
 poke128 ptr (Int128 a1 a0) =
@@ -438,8 +439,9 @@ poke128 ptr (Int128 a1 a0) =
 
 pokeElemOff128 :: Ptr Int128 -> Int -> Int128 -> IO ()
 pokeElemOff128 ptr idx (Int128 a1 a0) = do
-  pokeElemOff (castPtr ptr) (2 * idx + index0) a0
-  pokeElemOff (castPtr ptr) (2 * idx + index1) a1
+  let idx2 = 2 * idx
+  pokeElemOff (castPtr ptr) (idx2 + index0) a0
+  pokeElemOff (castPtr ptr) (idx2 + index1) a1
 
 -- -----------------------------------------------------------------------------
 -- Helpers.
@@ -470,23 +472,26 @@ alignment128# _ = 2# *# alignment# (undefined :: Word64)
 {-# INLINE indexByteArray128# #-}
 indexByteArray128# :: ByteArray# -> Int# -> Int128
 indexByteArray128# arr# i# =
-  let x = indexByteArray# arr# (2# *# (unInt index1))
-      y = indexByteArray# arr# (2# *# i# +# (unInt index0))
+  let i2# = 2# *# i#
+      x = indexByteArray# arr# (i2# +# unInt index1)
+      y = indexByteArray# arr# (i2# +# unInt index0)
   in Int128 x y
 
 {-# INLINE readByteArray128# #-}
 readByteArray128# :: MutableByteArray# s -> Int# -> State# s -> (# State# s, Int128 #)
 readByteArray128# arr# i# =
-  \s0 -> case readByteArray# arr# (2# *# (unInt index1)) s0 of
-    (# s1, x #) -> case readByteArray# arr# (2# *# i# +# (unInt index0)) s1 of
+  \s0 -> case readByteArray# arr# (i2# +# unInt index1) s0 of
+    (# s1, x #) -> case readByteArray# arr# (i2# +# unInt index0) s1 of
       (# s2, y #) -> (# s2, Int128 x y #)
+  where i2# = 2# *# i#
 
 {-# INLINE writeByteArray128# #-}
 writeByteArray128# :: MutableByteArray# s -> Int# -> Int128 -> State# s -> State# s
 writeByteArray128# arr# i# (Int128 a b) =
-  \s0 -> case writeByteArray# arr# (2# *# i# +# (unInt index1)) a s0 of
-    s1 -> case writeByteArray# arr# (2# *# i# +# (unInt index0)) b s1 of
+  \s0 -> case writeByteArray# arr# (i2# +# unInt index1) a s0 of
+    s1 -> case writeByteArray# arr# (i2# +# unInt index0) b s1 of
       s2 -> s2
+  where i2# = 2# *# i#
 
 {-# INLINE setByteArray128# #-}
 setByteArray128# :: MutableByteArray# s -> Int# -> Int# -> Int128 -> State# s -> State# s
@@ -495,23 +500,26 @@ setByteArray128# = defaultSetByteArray#
 {-# INLINE indexOffAddr128# #-}
 indexOffAddr128# :: Addr# -> Int# -> Int128
 indexOffAddr128# addr# i# =
-  let x = indexOffAddr# addr# (2# *# i# +# (unInt index1))
-      y = indexOffAddr# addr# (2# *# i# +# (unInt index0))
+  let i2# = 2# *# i#
+      x = indexOffAddr# addr# (i2# +# unInt index1)
+      y = indexOffAddr# addr# (i2# +# unInt index0)
   in Int128 x y
 
 {-# INLINE readOffAddr128# #-}
 readOffAddr128# :: Addr# -> Int# -> State# s -> (# State# s, Int128 #)
 readOffAddr128# addr# i# =
-  \s0 -> case readOffAddr# addr# (2# *# i# +# (unInt index1)) s0 of
-    (# s1, x #) -> case readOffAddr# addr# (2# *# i# +# (unInt index0)) s1 of
+  \s0 -> case readOffAddr# addr# (i2# +# unInt index1) s0 of
+    (# s1, x #) -> case readOffAddr# addr# (i2# +# unInt index0) s1 of
       (# s2, y #) -> (# s2, Int128 x y #)
+  where i2# = 2# *# i#
 
 {-# INLINE writeOffAddr128# #-}
 writeOffAddr128# :: Addr# -> Int# -> Int128 -> State# s -> State# s
 writeOffAddr128# addr# i# (Int128 a b) =
-  \s0 -> case writeOffAddr# addr# (2# *# i# +# (unInt index1)) a s0 of
-    s1 -> case writeOffAddr# addr# (2# *# i# +# (unInt index0)) b s1 of
+  \s0 -> case writeOffAddr# addr# (i2# +# unInt index1) a s0 of
+    s1 -> case writeOffAddr# addr# (i2# +# unInt index0) b s1 of
       s2 -> s2
+  where i2# = 2# *# i#
 
 {-# INLINE setOffAddr128# #-}
 setOffAddr128# :: Addr# -> Int# -> Int# -> Int128 -> State# s -> State# s

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -443,8 +443,9 @@ peek128 ptr =
 
 peekElemOff128 :: Ptr Word128 -> Int -> IO Word128
 peekElemOff128 ptr idx =
-  Word128 <$> peekElemOff (castPtr ptr) (2 * idx + index1)
-            <*> peekElemOff (castPtr ptr) (2 * idx + index0)
+  Word128 <$> peekElemOff (castPtr ptr) (idx2 + index1)
+            <*> peekElemOff (castPtr ptr) (idx2 + index0)
+  where idx2 = 2 * idx
 
 poke128 :: Ptr Word128 -> Word128 -> IO ()
 poke128 ptr (Word128 a1 a0) =
@@ -452,8 +453,9 @@ poke128 ptr (Word128 a1 a0) =
 
 pokeElemOff128 :: Ptr Word128 -> Int -> Word128 -> IO ()
 pokeElemOff128 ptr idx (Word128 a1 a0) = do
-  pokeElemOff (castPtr ptr) (2 * idx + index0) a0
-  pokeElemOff (castPtr ptr) (2 * idx + index1) a1
+  let idx2 = 2 * idx
+  pokeElemOff (castPtr ptr) (idx2 + index0) a0
+  pokeElemOff (castPtr ptr) (idx2 + index1) a1
 
 -- -----------------------------------------------------------------------------
 -- Functions for `Prim` instance.
@@ -469,23 +471,26 @@ alignment128# _ = 2# *# alignment# (undefined :: Word64)
 {-# INLINE indexByteArray128# #-}
 indexByteArray128# :: ByteArray# -> Int# -> Word128
 indexByteArray128# arr# i# =
-  let x = indexByteArray# arr# (2# *# i# +# (unInt index1))
-      y = indexByteArray# arr# (2# *# i# +# (unInt index0))
+  let i2# = 2# *# i#
+      x = indexByteArray# arr# (i2# +# unInt index1)
+      y = indexByteArray# arr# (i2# +# unInt index0)
   in Word128 x y
 
 {-# INLINE readByteArray128# #-}
 readByteArray128# :: MutableByteArray# s -> Int# -> State# s -> (# State# s, Word128 #)
 readByteArray128# arr# i# =
-  \s0 -> case readByteArray# arr# (2# *# i# +# (unInt index1)) s0 of
-    (# s1, x #) -> case readByteArray# arr# (2# *# i# +# (unInt index0)) s1 of
+  \s0 -> case readByteArray# arr# (i2# +# unInt index1) s0 of
+    (# s1, x #) -> case readByteArray# arr# (i2# +# unInt index0) s1 of
       (# s2, y #) -> (# s2, Word128 x y #)
+  where i2# = 2# *# i#
 
 {-# INLINE writeByteArray128# #-}
 writeByteArray128# :: MutableByteArray# s -> Int# -> Word128 -> State# s -> State# s
 writeByteArray128# arr# i# (Word128 a b) =
-  \s0 -> case writeByteArray# arr# (2# *# i# +# (unInt index1)) a s0 of
-    s1 -> case writeByteArray# arr# (2# *# i# +# (unInt index0)) b s1 of
+  \s0 -> case writeByteArray# arr# (i2# +# unInt index1) a s0 of
+    s1 -> case writeByteArray# arr# (i2# +# unInt index0) b s1 of
       s2 -> s2
+  where i2# = 2# *# i#
 
 {-# INLINE setByteArray128# #-}
 setByteArray128# :: MutableByteArray# s -> Int# -> Int# -> Word128 -> State# s -> State# s
@@ -494,23 +499,26 @@ setByteArray128# = defaultSetByteArray#
 {-# INLINE indexOffAddr128# #-}
 indexOffAddr128# :: Addr# -> Int# -> Word128
 indexOffAddr128# addr# i# =
-  let x = indexOffAddr# addr# (2# *# i# +# (unInt index1))
-      y = indexOffAddr# addr# (2# *# i# +# (unInt index0))
+  let i2# = 2# *# i#
+      x = indexOffAddr# addr# (i2# +# unInt index1)
+      y = indexOffAddr# addr# (i2# +# unInt index0)
   in Word128 x y
 
 {-# INLINE readOffAddr128# #-}
 readOffAddr128# :: Addr# -> Int# -> State# s -> (# State# s, Word128 #)
 readOffAddr128# addr# i# =
-  \s0 -> case readOffAddr# addr# (2# *# i# +# (unInt index1)) s0 of
-    (# s1, x #) -> case readOffAddr# addr# (2# *# i# +# (unInt index0)) s1 of
+  \s0 -> case readOffAddr# addr# (i2# +# unInt index1) s0 of
+    (# s1, x #) -> case readOffAddr# addr# (i2# +# unInt index0) s1 of
       (# s2, y #) -> (# s2, Word128 x y #)
+  where i2# = 2# *# i#
 
 {-# INLINE writeOffAddr128# #-}
 writeOffAddr128# :: Addr# -> Int# -> Word128 -> State# s -> State# s
 writeOffAddr128# addr# i# (Word128 a b) =
-  \s0 -> case writeOffAddr# addr# (2# *# i# +# (unInt index1)) a s0 of
-    s1 -> case writeOffAddr# addr# (2# *# i# +# (unInt index0)) b s1 of
+  \s0 -> case writeOffAddr# addr# (i2# +# unInt index1) a s0 of
+    s1 -> case writeOffAddr# addr# (i2# +# unInt index0) b s1 of
       s2 -> s2
+  where i2# = 2# *# i#
 
 {-# INLINE setOffAddr128# #-}
 setOffAddr128# :: Addr# -> Int# -> Int# -> Word128 -> State# s -> State# s

--- a/test/Test/Data/WideWord/Word128.hs
+++ b/test/Test/Data/WideWord/Word128.hs
@@ -5,11 +5,14 @@ module Test.Data.WideWord.Word128
 
 import           Control.Exception (ArithException, evaluate, try)
 import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad (unless)
 
 import           Data.Bifunctor (bimap)
 import           Data.Bits ((.&.), (.|.), bit, complement, countLeadingZeros, countTrailingZeros
                             , popCount, rotateL, rotateR, shiftL, shiftR, testBit, xor)
-import           Data.Word (Word64, byteSwap64)
+import           Data.Primitive.PrimArray
+import           Data.Primitive.Ptr
+import           Data.Word (Word8, Word64, byteSwap64)
 import           Data.WideWord
 
 import           Foreign (allocaBytes)
@@ -304,6 +307,48 @@ prop_peekElemOff_pokeElemOff =
                     pokeElemOff ptr 1 b128
                     (,) <$> peekElemOff ptr 0 <*>  peekElemOff ptr 1
     (toInteger128 ar, toInteger128 br) === (toInteger128 a128, toInteger128 b128)
+
+
+prop_ToFromPrimArray :: Property
+prop_ToFromPrimArray =
+  propertyCount $ do
+    as <- H.forAll $
+      Gen.list (fromIntegral <$> (Range.linearBounded :: Range.Range Word8)) genWord128
+    as === primArrayToList (primArrayFromList as)
+
+
+prop_WriteReadPrimArray :: Property
+prop_WriteReadPrimArray =
+  propertyCount $ do
+    as <- H.forAll $ Gen.list (Range.linear 1 256) genWord128
+    unless (null as) $ do
+      let len = length as
+          arr = primArrayFromList as
+      i <- (`mod` len) <$> H.forAll (Gen.int (Range.linear 0 (len - 1)))
+      new <- H.forAll genWord128
+      props <- liftIO $ do
+        marr <- unsafeThawPrimArray arr
+        prev <- readPrimArray marr i
+        let prevProp = prev === (as !! i)
+        writePrimArray marr i new
+        cur <- readPrimArray marr i
+        setPrimArray marr i 1 prev
+        arr' <- unsafeFreezePrimArray marr
+        return [prevProp, cur === new, arr === arr']
+      sequence_ props
+
+prop_readOffPtr_writeOffPtr :: Property
+prop_readOffPtr_writeOffPtr =
+  propertyCount $ do
+    a128 <- H.forAll genWord128
+    b128 <- H.forAll genWord128
+    (ar, br) <- liftIO $
+                  allocaBytes (2 * sizeOf zeroWord128) $ \ ptr -> do
+                    writeOffPtr ptr 0 a128
+                    writeOffPtr ptr 1 b128
+                    (,) <$> readOffPtr ptr 0 <*> readOffPtr ptr 1
+    (ar, br) === (a128, b128)
+
 
 -- -----------------------------------------------------------------------------
 

--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                wide-word
-version:             0.1.0.8
+version:             0.1.0.9
 synopsis:            Data types for large but fixed width signed and unsigned integers
 description:
   A library to provide data types for large (ie > 64 bits) but fixed width signed
@@ -55,6 +55,7 @@ test-suite test
                      , bytestring                    >= 0.10
                      , ghc-prim
                      , hedgehog                      == 0.6.*
+                     , primitive
                      , wide-word
 
 test-suite laws
@@ -68,5 +69,5 @@ test-suite laws
   build-depends:       base                          >= 4.8         && < 5.0
                      , QuickCheck                    >= 2.9.2       && < 2.13
                      , quickcheck-classes            >= 0.4.0       && < 0.7.0
-                     , semirings                     >= 0.2         && < 0.3
+                     , semirings                     >= 0.2
                      , wide-word


### PR DESCRIPTION
Major fix in this PR is that both `indexByteArray128#` and `readByteArray128#` for `Int128` had the indexing wrong which resulted in completely wrong values being read from `MutableByteArray` and indexed from `ByteArray`. It is a pretty serious bug, so it might be worth deprecating version `0.1.0.8` on hackage, but it is of course up to you.

In the process of fixing the problem did a little optimization (remove duplicate multiplications), which would likely be caught by the compiler, but nevertheless it was a good way for me to do a sanity check that indexing now is correct.

Added some hedgehog tests for both 128bit Prim instances. Coverage is now at 87%:
```
Generating unified report
 90% expressions used (1691/1866)
 63% boolean coverage (67/105)
      66% guards (67/101), 24 always True, 6 always False, 4 unevaluated
       0% 'if' conditions (0/4), 4 always False
     100% qualifiers (0/0)
 88% alternatives used (116/131)
 86% local declarations used (63/73)
 87% top-level declarations used (201/231)
```

Within last month new version of `semirings-0.3` was release. Removed the upper bound on semirings, there seem to be no compilation errors or warnings.