### PR TITLE
Make NFData instances do less work

### DIFF
--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -146,7 +146,7 @@ instance Storable Int128 where
   pokeElemOff = pokeElemOff128
 
 instance NFData Int128 where
-  rnf (Int128 a1 a0) = rnf a1 `seq` rnf a0
+  rnf !_ = ()
 
 instance Prim Int128 where
   sizeOf#         = sizeOf128#

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -143,7 +143,7 @@ instance Storable Word128 where
   pokeElemOff = pokeElemOff128
 
 instance NFData Word128 where
-  rnf (Word128 a1 a0) = rnf a1 `seq` rnf a0
+  rnf !_ = ()
 
 instance Prim Word128 where
   sizeOf#         = sizeOf128#

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -151,8 +151,7 @@ instance Storable Word256 where
   pokeElemOff = pokeElemOff256
 
 instance NFData Word256 where
-  rnf (Word256 a3 a2 a1 a0) =
-    rnf a3 `seq` rnf a2 `seq` rnf a1 `seq` rnf a0
+  rnf !_ = ()
 
 instance Prim Word256 where
   sizeOf#         = sizeOf256#


### PR DESCRIPTION
Since all the fields are strict (and unpacked), there's no need to force the fields, evaluating the constructor is enough to ensure it is fully evaluated. No idea if this will actually make a change in performance, but it does reduce unnecessary code.