### PR TITLE
Simplify Ord instances

### DIFF
--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -188,10 +188,7 @@ instance Prim Int128 where
 
 compare128 :: Int128 -> Int128 -> Ordering
 compare128 (Int128 a1 a0) (Int128 b1 b0) =
-  case compare (int64OfWord64 a1) (int64OfWord64 b1) of
-    EQ -> compare a0 b0
-    LT -> LT
-    GT -> GT
+  compare (int64OfWord64 a1) (int64OfWord64 b1) <> compare a0 b0
   where
     int64OfWord64 (W64# w) = I64# (word2Int# w)
 

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -188,11 +188,7 @@ instance Prim Word128 where
 -- Functions for `Ord` instance.
 
 compare128 :: Word128 -> Word128 -> Ordering
-compare128 (Word128 a1 a0) (Word128 b1 b0) =
-  case compare a1 b1 of
-    EQ -> compare a0 b0
-    LT -> LT
-    GT -> GT
+compare128 (Word128 a1 a0) (Word128 b1 b0) = compare a1 b1 <> compare a0 b0
 
 -- -----------------------------------------------------------------------------
 -- Functions for `Enum` instance.

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -198,16 +198,7 @@ instance Prim Word256 where
 
 compare256 :: Word256 -> Word256 -> Ordering
 compare256 (Word256 a3 a2 a1 a0) (Word256 b3 b2 b1 b0) =
-  case compare a3 b3 of
-    LT -> LT
-    GT -> GT
-    EQ -> case compare a2 b2 of
-      LT -> LT
-      GT -> GT
-      EQ -> case compare a1 b1 of
-        LT -> LT
-        GT -> GT
-        EQ -> compare a0 b0
+  compare a3 b3 <> compare a2 b2 <> compare a1 b1 <>compare a0 b0
 
 -- -----------------------------------------------------------------------------
 -- Functions for `Enum` instance.


### PR DESCRIPTION
The case statements used for the implementations of Compare are exactly the definitions of the Semigroup instance for Ordering. Let me know if you need support back to GHC versions which don't export `<>` by default and I'll add the appropriate `ifdefs`.