### PR TITLE
Add cases for arch with word size less than 64 bit.

### DIFF
--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -39,6 +39,7 @@ library
   build-depends:       base                          >= 4.8         && < 4.14
                      , deepseq                       >= 1.3         && < 1.5
                      , primitive                     >= 0.6.4.0     && < 0.8
+                     , ghc-prim
 
 test-suite test
   default-language:   Haskell2010


### PR DESCRIPTION
Fix #36. It is not so beauty with added conversion everywhere, but it is as close to the original as possible.