### PR TITLE
test/laws.hs: Use arbitraryBoundedIntegral instead of arbitrary

### DIFF
--- a/test/laws.hs
+++ b/test/laws.hs
@@ -55,10 +55,14 @@ allLaws p = map ($ p)
   ]
 
 instance Arbitrary Word128 where
-  arbitrary = Word128 <$> arbitrary <*> arbitrary
+  arbitrary =
+    Word128 <$> arbitraryBoundedIntegral <*> arbitraryBoundedIntegral
 
 instance Arbitrary Word256 where
-  arbitrary = Word256 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary =
+    Word256
+      <$> arbitraryBoundedIntegral <*> arbitraryBoundedIntegral
+      <*> arbitraryBoundedIntegral <*> arbitraryBoundedIntegral
   shrink x
     | x == 0 = []
     | x == 1 = [0]


### PR DESCRIPTION
The 'arbitrary' instance for 'Word64' generates values that only
exercise a tiny portion of the 'Word64' space. Switch to a new
arbitrary function to correct this.