### PR TITLE
Make Prim and Storable instances agree

### DIFF
--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -141,8 +141,8 @@ instance Integral Int128 where
   toInteger = toInteger128
 
 instance Storable Int128 where
-  sizeOf _ = 2 * sizeOf (0 :: Word64)
-  alignment _ = 2 * alignment (0 :: Word64)
+  sizeOf i = I# (sizeOf128# i)
+  alignment i = I# (alignment128# i)
   peek = peek128
   peekElemOff = peekElemOff128
   poke = poke128

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -138,8 +138,8 @@ instance Integral Word128 where
   toInteger = toInteger128
 
 instance Storable Word128 where
-  sizeOf _ = 2 * sizeOf (0 :: Word64)
-  alignment _ = 2 * alignment (0 :: Word64)
+  sizeOf w = I# (sizeOf128# w)
+  alignment w = I# (alignment128# w)
   peek = peek128
   peekElemOff = peekElemOff128
   poke = poke128
@@ -470,11 +470,11 @@ pokeElemOff128 ptr idx (Word128 a1 a0) = do
 
 {-# INLINE sizeOf128# #-}
 sizeOf128# :: Word128 -> Int#
-sizeOf128# _ = 2# *# sizeOf# (undefined :: Word64)
+sizeOf128# _ = 2# *# sizeOf# (0 :: Word64)
 
 {-# INLINE alignment128# #-}
 alignment128# :: Word128 -> Int#
-alignment128# _ = 2# *# alignment# (undefined :: Word64)
+alignment128# _ = 2# *# alignment# (0 :: Word64)
 
 {-# INLINE indexByteArray128# #-}
 indexByteArray128# :: ByteArray# -> Int# -> Word128

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -41,7 +41,7 @@ import Data.Semigroup ((<>))
 import Foreign.Ptr (Ptr, castPtr)
 import Foreign.Storable (Storable (..))
 
-import GHC.Base (Int (..), and#, int2Word#, minusWord#, not#, or#, plusWord#, plusWord2#
+import GHC.Base (Int (..), and#, minusWord#, not#, or#, plusWord#, plusWord2#
                 , subWordC#, timesWord#, timesWord2#, xor#)
 import GHC.Enum (predError, succError)
 import GHC.Exts ((*#), (+#), Int#, State#, ByteArray#, MutableByteArray#, Addr#)
@@ -146,8 +146,8 @@ instance Integral Word256 where
   toInteger = toInteger256
 
 instance Storable Word256 where
-  sizeOf _ = 4 * sizeOf (0 :: Word64)
-  alignment _ = 4 * alignment (0 :: Word64)
+  sizeOf w = I# (sizeOf256# w)
+  alignment w = I# (alignment256# w)
   peek = peek256
   peekElemOff = peekElemOff256
   poke = poke256
@@ -537,11 +537,11 @@ pokeElemOff256 ptr idx (Word256 a3 a2 a1 a0) = do
 
 {-# INLINE sizeOf256# #-}
 sizeOf256# :: Word256 -> Int#
-sizeOf256# _ = 4# *# sizeOf# (undefined :: Word64)
+sizeOf256# _ = 4# *# sizeOf# (0 :: Word64)
 
 {-# INLINE alignment256# #-}
 alignment256# :: Word256 -> Int#
-alignment256# _ = alignment# (undefined :: Word64)
+alignment256# _ = 4# *# alignment# (0 :: Word64)
 
 {-# INLINE indexByteArray256# #-}
 indexByteArray256# :: ByteArray# -> Int# -> Word256


### PR DESCRIPTION
Specifically 'sizeOf' and 'alignment' related methods. It
would be nice to have a test for this.

Closes: https://github.com/erikd/wide-word/pull/40