### PR TITLE
Add Drone CI i386 build to test 32bit arch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,24 @@
+kind: pipeline
+name: i386
+platform: { os: linux, arch: amd64 }
+steps:
+- name: Test
+  image: i386/ubuntu
+  commands:
+    - export LC_ALL=C.UTF-8
+    - apt-get update -y
+    - apt-get install -y ghc cabal-install zlib1g-dev
+    # Build and install a modern cabal
+    - cabal --version
+    - cabal update
+    - cabal install cabal-install
+    - export PATH="$HOME/.cabal/bin:$PATH"
+    - hash -r
+    # Now with a modern cabal
+    - cabal --version
+    - cabal update
+    - cabal configure --enable-tests --constraint="quickcheck-classes -aeson -semigroupoids -vector"
+    - cabal build
+    - cabal test --test-show-details=streaming -j1
+    - cabal haddock
+    - cabal sdist


### PR DESCRIPTION
This adds a 32bit build, as discussed in #38. It fails indeed with 
```
src/Data/WideWord/Word256.hs:54:1: error:
    Failed to load interface for ‘GHC.IntWord64’
    It is a member of the hidden package ‘ghc-prim-0.5.0.0’.
    Perhaps you need to add ‘ghc-prim’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```
See https://cloud.drone.io/Bodigrim/wide-word/17/1/2 for full logs. 

----

There might be a better way to implement it: I discovered that I forgot completely how to use Cabal 1.24, so the only working recipe I came up with is to build Cabal 3.0 first. 