### PR TITLE
`hedgehog-1.2` version bound bump

### DIFF
--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -63,7 +63,7 @@ test-suite test
   build-depends:       base
                      , bytestring                    >= 0.10
                      , ghc-prim
-                     , hedgehog                      >= 1.0 && < 1.2
+                     , hedgehog                      >= 1.0 && < 1.3
                      , primitive
                      , wide-word
 


### PR DESCRIPTION
Checked this out locally and it works.