### PR TITLE
Add Binary instances

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for wide-word
 
+## 0.1.5.0 -- 2023-mm-dd
+
+* Add Binary instances for Int128, Word128 and Word256.
+
 ## 0.1.4.0 -- 2022-12-24
 
 * Add support for building on 32 bit architectures with ghc-9.2 or later.

--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -56,6 +56,7 @@ import GHC.Word (Word32, Word64, byteSwap64)
 import Data.Primitive.Types (Prim (..), defaultSetByteArray#, defaultSetOffAddr#)
 
 import Data.Hashable (Hashable,hashWithSalt)
+import Data.Binary (Binary (get,put))
 
 import Data.WideWord.Word64
 
@@ -70,9 +71,14 @@ data Int128 = Int128
   , int128Lo64 :: !Word64
   }
   deriving (Eq, Data, Generic, Ix, Typeable)
-
+ 
 instance Hashable Int128 where
   hashWithSalt s (Int128 a1 a2) = s `hashWithSalt` a1 `hashWithSalt` a2
+
+-- | @since 0.1.5.0
+instance Binary Int128 where
+  put (Int128 a1 a2) = put a1 >> put a2
+  get = Int128 <$> get <*> get
 
 byteSwapInt128 :: Int128 -> Int128
 byteSwapInt128 (Int128 a1 a0) = Int128 (byteSwap64 a0) (byteSwap64 a1)

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -56,6 +56,7 @@ import Numeric (showHex)
 import Data.Primitive.Types (Prim (..), defaultSetByteArray#, defaultSetOffAddr#)
 
 import Data.Hashable (Hashable,hashWithSalt)
+import Data.Binary (Binary (get,put))
 
 data Word128 = Word128
   { word128Hi64 :: !Word64
@@ -65,6 +66,11 @@ data Word128 = Word128
 
 instance Hashable Word128 where
   hashWithSalt s (Word128 a1 a2) = s `hashWithSalt` a1 `hashWithSalt` a2
+
+-- | @since 0.1.5.0
+instance Binary Word128 where
+  put (Word128 a1 a2) = put a1 >> put a2
+  get = Word128 <$> get <*> get
 
 byteSwapWord128 :: Word128 -> Word128
 byteSwapWord128 (Word128 a1 a0) = Word128 (byteSwap64 a0) (byteSwap64 a1)

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -53,6 +53,7 @@ import Numeric (showHex)
 
 import Data.Primitive.Types (Prim (..), defaultSetByteArray#, defaultSetOffAddr#)
 import Data.Hashable (Hashable,hashWithSalt)
+import Data.Binary (Binary (get,put))
 
 {- HLINT ignore "Use guards" -}
 
@@ -67,6 +68,11 @@ data Word256 = Word256
 instance Hashable Word256 where
   hashWithSalt s (Word256 a1 a2 a3 a4) =
     s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3 `hashWithSalt` a4
+
+-- | @since 0.1.5.0
+instance Binary Word256 where
+  put (Word256 a1 a2 a3 a4) = put a1 >> put a2 >> put a3 >> put a4
+  get = Word256 <$> get <*> get <*> get <*> get
 
 showHexWord256 :: Word256 -> String
 showHexWord256 (Word256 a3 a2 a1 a0)

--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                wide-word
-version:             0.1.4.0
+version:             0.1.5.0
 synopsis:            Data types for large but fixed width signed and unsigned integers
 description:
   A library to provide data types for large (ie > 64 bits) but fixed width signed
@@ -42,7 +42,8 @@ library
   other-modules:       Data.WideWord.Compat
 
   build-depends:       base                          >= 4.9         && < 4.18
-                     , deepseq                       >= 1.3         && < 1.5
+                     , binary                        >= 0.8.3.0     && < 0.9
+                     , deepseq                       >= 1.4.2.0     && < 1.5
                      -- Required so that GHC.IntWord64 is available on 32 bit systems
                      , ghc-prim
                      , primitive                     >= 0.6.4.0     && < 0.8


### PR DESCRIPTION
Also bump the lower bound of deepseq to the version bundled with GHC-8.0.2.

Resolves #50, and part of #56