### PR TITLE
build with primitive 0.8

### DIFF
--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -46,7 +46,7 @@ library
                      , deepseq                       >= 1.4.2.0     && < 1.5
                      -- Required so that GHC.IntWord64 is available on 32 bit systems
                      , ghc-prim
-                     , primitive                     >= 0.6.4.0     && < 0.8
+                     , primitive                     >= 0.6.4.0     && < 0.9
                      , hashable                      >= 1.2         && < 1.5
 
 test-suite test


### PR DESCRIPTION
Builds with revisions to all affected dependencies:
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=quickcheck-classes:primitive --allow-newer=primitive-addr:primitive --allow-newer=hedgehog:primitive --allow-newer=aeson:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - aeson-2.1.1.0 (lib) (requires build)
 - wide-word-0.1.5.0 (lib) (first run)
 - quickcheck-classes-0.6.5.0 (lib) (requires build)
 - wide-word-0.1.5.0 (test:test) (first run)
 - wide-word-0.1.5.0 (test:laws) (first run)
Configuring library for wide-word-0.1.5.0..
Starting     aeson-2.1.1.0 (lib)
Preprocessing library for wide-word-0.1.5.0..
Building library for wide-word-0.1.5.0..
Building     aeson-2.1.1.0 (lib)
[1 of 6] Compiling Data.WideWord.Compat ( src/Data/WideWord/Compat.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Compat.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Compat.dyn_o )
[2 of 6] Compiling Data.WideWord.Word64 ( src/Data/WideWord/Word64.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word64.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word64.dyn_o )
[3 of 6] Compiling Data.WideWord.Word256 ( src/Data/WideWord/Word256.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word256.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word256.dyn_o )

src/Data/WideWord/Word256.hs:201:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
201 | "fromIntegral :: Word256 -> Word256" fromIntegral = id :: Word256 -> Word256
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:203:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
203 | "fromIntegral :: Int -> Word256"     fromIntegral = fromInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:204:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
204 | "fromIntegral :: Word -> Word256"    fromIntegral = fromWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:205:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word32 -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
205 | "fromIntegral :: Word32 -> Word256"  fromIntegral = fromWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:206:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word64 -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
206 | "fromIntegral :: Word64 -> Word256"  fromIntegral = Word256 0 0 0
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:208:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Int" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
208 | "fromIntegral :: Word256 -> Int"     fromIntegral = toInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:209:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
209 | "fromIntegral :: Word256 -> Word"    fromIntegral = toWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:210:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word32" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
210 | "fromIntegral :: Word256 -> Word32"  fromIntegral = toWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:211:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word64" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
211 | "fromIntegral :: Word256 -> Word64"  fromIntegral = \(Word256 _ _ _ w) -> w
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[4 of 6] Compiling Data.WideWord.Word128 ( src/Data/WideWord/Word128.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word128.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word128.dyn_o )

src/Data/WideWord/Word128.hs:191:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
191 | "fromIntegral :: Word128 -> Word128" fromIntegral = id :: Word128 -> Word128
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:193:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
193 | "fromIntegral :: Int -> Word128"     fromIntegral = fromInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:194:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
194 | "fromIntegral :: Word -> Word128"    fromIntegral = fromWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:195:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word32 -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
195 | "fromIntegral :: Word32 -> Word128"  fromIntegral = fromWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:196:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word64 -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
196 | "fromIntegral :: Word64 -> Word128"  fromIntegral = Word128 0
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:198:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Int" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
198 | "fromIntegral :: Word128 -> Int"     fromIntegral = toInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:199:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
199 | "fromIntegral :: Word128 -> Word"    fromIntegral = toWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:200:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word32" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
200 | "fromIntegral :: Word128 -> Word32"  fromIntegral = toWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:201:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word64" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
201 | "fromIntegral :: Word128 -> Word64"  fromIntegral = \(Word128 _ w) -> w
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[5 of 6] Compiling Data.WideWord.Int128 ( src/Data/WideWord/Int128.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Int128.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Int128.dyn_o )

src/Data/WideWord/Int128.hs:198:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
198 | "fromIntegral :: Int -> Int128"     fromIntegral = fromInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:199:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
199 | "fromIntegral :: Word -> Int128"    fromIntegral = fromWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:200:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word32 -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
200 | "fromIntegral :: Word32 -> Int128"  fromIntegral = fromWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:201:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word64 -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
201 | "fromIntegral :: Word64 -> Int128"  fromIntegral = Int128 0
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:203:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Int" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
203 | "fromIntegral :: Int128 -> Int"     fromIntegral = toInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:204:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Word" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
204 | "fromIntegral :: Int128 -> Word"    fromIntegral = toWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:205:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Word32" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
205 | "fromIntegral :: Int128 -> Word32"  fromIntegral = toWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:206:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Word64" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
206 | "fromIntegral :: Int128 -> Word64"  fromIntegral = \(Int128 _ w) -> w
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6 of 6] Compiling Data.WideWord    ( src/Data/WideWord.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord.dyn_o )
^C

wide-word on  master [!] via λ 9.4.4 via ❄️  impure (shell) took 6s
❯ cabal clean

wide-word on  master [!] via λ 9.4.4 via ❄️  impure (shell)
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=quickcheck-classes:primitive --allow-newer=primitive-addr:primitive --allow-newer=hedgehog:primitive --allow-newer=aeson:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - aeson-2.1.1.0 (lib) (requires build)
 - wide-word-0.1.5.0 (lib) (first run)
 - quickcheck-classes-0.6.5.0 (lib) (requires build)
 - wide-word-0.1.5.0 (test:test) (first run)
 - wide-word-0.1.5.0 (test:laws) (first run)
Configuring library for wide-word-0.1.5.0..
Starting     aeson-2.1.1.0 (lib)
Preprocessing library for wide-word-0.1.5.0..
Building library for wide-word-0.1.5.0..
Building     aeson-2.1.1.0 (lib)
[1 of 6] Compiling Data.WideWord.Compat ( src/Data/WideWord/Compat.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Compat.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Compat.dyn_o )
[2 of 6] Compiling Data.WideWord.Word64 ( src/Data/WideWord/Word64.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word64.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word64.dyn_o )
[3 of 6] Compiling Data.WideWord.Word256 ( src/Data/WideWord/Word256.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word256.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word256.dyn_o )

src/Data/WideWord/Word256.hs:201:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
201 | "fromIntegral :: Word256 -> Word256" fromIntegral = id :: Word256 -> Word256
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:203:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
203 | "fromIntegral :: Int -> Word256"     fromIntegral = fromInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:204:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
204 | "fromIntegral :: Word -> Word256"    fromIntegral = fromWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:205:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word32 -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
205 | "fromIntegral :: Word32 -> Word256"  fromIntegral = fromWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:206:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word64 -> Word256" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
206 | "fromIntegral :: Word64 -> Word256"  fromIntegral = Word256 0 0 0
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:208:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Int" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
208 | "fromIntegral :: Word256 -> Int"     fromIntegral = toInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:209:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
209 | "fromIntegral :: Word256 -> Word"    fromIntegral = toWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:210:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word32" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
210 | "fromIntegral :: Word256 -> Word32"  fromIntegral = toWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word256.hs:211:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word256 -> Word64" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
211 | "fromIntegral :: Word256 -> Word64"  fromIntegral = \(Word256 _ _ _ w) -> w
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[4 of 6] Compiling Data.WideWord.Word128 ( src/Data/WideWord/Word128.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word128.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Word128.dyn_o )

src/Data/WideWord/Word128.hs:191:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
191 | "fromIntegral :: Word128 -> Word128" fromIntegral = id :: Word128 -> Word128
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:193:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
193 | "fromIntegral :: Int -> Word128"     fromIntegral = fromInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:194:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
194 | "fromIntegral :: Word -> Word128"    fromIntegral = fromWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:195:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word32 -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
195 | "fromIntegral :: Word32 -> Word128"  fromIntegral = fromWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:196:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word64 -> Word128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
196 | "fromIntegral :: Word64 -> Word128"  fromIntegral = Word128 0
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:198:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Int" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
198 | "fromIntegral :: Word128 -> Int"     fromIntegral = toInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:199:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
199 | "fromIntegral :: Word128 -> Word"    fromIntegral = toWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:200:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word32" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
200 | "fromIntegral :: Word128 -> Word32"  fromIntegral = toWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Word128.hs:201:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word128 -> Word64" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
201 | "fromIntegral :: Word128 -> Word64"  fromIntegral = \(Word128 _ w) -> w
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[5 of 6] Compiling Data.WideWord.Int128 ( src/Data/WideWord/Int128.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Int128.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord/Int128.dyn_o )

src/Data/WideWord/Int128.hs:198:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
198 | "fromIntegral :: Int -> Int128"     fromIntegral = fromInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:199:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
199 | "fromIntegral :: Word -> Int128"    fromIntegral = fromWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:200:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word32 -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
200 | "fromIntegral :: Word32 -> Int128"  fromIntegral = fromWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:201:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Word64 -> Int128" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
201 | "fromIntegral :: Word64 -> Int128"  fromIntegral = Int128 0
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:203:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Int" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
203 | "fromIntegral :: Int128 -> Int"     fromIntegral = toInt
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:204:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Word" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
204 | "fromIntegral :: Int128 -> Word"    fromIntegral = toWord
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:205:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Word32" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
205 | "fromIntegral :: Int128 -> Word32"  fromIntegral = toWord32
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/WideWord/Int128.hs:206:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral :: Int128 -> Word64" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
206 | "fromIntegral :: Int128 -> Word64"  fromIntegral = \(Int128 _ w) -> w
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[6 of 6] Compiling Data.WideWord    ( src/Data/WideWord.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/build/Data/WideWord.dyn_o )
Configuring test suite 'test' for wide-word-0.1.5.0..
Preprocessing test suite 'test' for wide-word-0.1.5.0..
Building test suite 'test' for wide-word-0.1.5.0..
[1 of 5] Compiling Test.Data.WideWord.Gen ( test/Test/Data/WideWord/Gen.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Gen.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Gen.dyn_o )
[2 of 5] Compiling Test.Data.WideWord.Int128 ( test/Test/Data/WideWord/Int128.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Int128.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Int128.dyn_o )
[3 of 5] Compiling Test.Data.WideWord.Word128 ( test/Test/Data/WideWord/Word128.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Word128.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Word128.dyn_o )
[4 of 5] Compiling Test.Data.WideWord.Word64 ( test/Test/Data/WideWord/Word64.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Word64.o, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Test/Data/WideWord/Word64.dyn_o )
[5 of 5] Compiling Main             ( test/test.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test-tmp/Main.o )
[6 of 6] Linking /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/test/build/test/test
Installing   aeson-2.1.1.0 (lib)
Completed    aeson-2.1.1.0 (lib)
Starting     quickcheck-classes-0.6.5.0 (lib)
Building     quickcheck-classes-0.6.5.0 (lib)
Installing   quickcheck-classes-0.6.5.0 (lib)
Completed    quickcheck-classes-0.6.5.0 (lib)
Configuring test suite 'laws' for wide-word-0.1.5.0..
Preprocessing test suite 'laws' for wide-word-0.1.5.0..
Building test suite 'laws' for wide-word-0.1.5.0..
[1 of 1] Compiling Main             ( test/laws.hs, /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/laws/build/laws/laws-tmp/Main.o )
[2 of 2] Linking /home/chessai/haskell/wide-word/dist-newstyle/build/x86_64-linux/ghc-9.4.4/wide-word-0.1.5.0/t/laws/build/laws/laws
```