### PR TITLE
Fix rotateL, shiftL and shiftR for negative count

### DIFF
--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -349,7 +349,8 @@ xor128 (Int128 a1 a0) (Int128 b1 b0) =
 shiftL128 :: Int128 -> Int -> Int128
 shiftL128 w@(Int128 a1 a0) s
   | s == 0 = w
-  | s < 0 = shiftL128 w (128 - (abs s `mod` 128))
+  | s == minBound = zeroInt128
+  | s < 0 = shiftR128 w (negate s)
   | s >= 128 = zeroInt128
   | s == 64 = Int128 a0 0
   | s > 64 = Int128 (a0 `shiftL` (s - 64)) 0
@@ -359,8 +360,9 @@ shiftL128 w@(Int128 a1 a0) s
 {-# INLINABLE shiftR128 #-}
 shiftR128 :: Int128 -> Int -> Int128
 shiftR128 i@(Int128 a1 a0) s
-  | s < 0 = zeroInt128
   | s == 0 = i
+  | s == minBound = zeroInt128
+  | s < 0 = shiftL128 i (negate s)
   | topBitSetWord64 a1 = complement128 (shiftR128 (complement128 i) s)
   | s >= 128 = zeroInt128
   | s == 64 = Int128 0 a1

--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -370,7 +370,7 @@ shiftR128 i@(Int128 a1 a0) s
 {-# INLINABLE rotateL128 #-}
 rotateL128 :: Int128 -> Int -> Int128
 rotateL128 w@(Int128 a1 a0) r
-  | r < 0 = zeroInt128
+  | r < 0 = rotateL128 w (128 - (abs r `mod` 128))
   | r == 0 = w
   | r >= 128 = rotateL128 w (r `mod` 128)
   | r == 64 = Int128 a0 a1

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -360,7 +360,7 @@ shiftR128 w@(Word128 a1 a0) s
 rotateL128 :: Word128 -> Int -> Word128
 rotateL128 w@(Word128 a1 a0) r
   | r == 0 = w
-  | r < 0 = zeroWord128
+  | r < 0 = rotateL128 w (128 - (abs r `mod` 128))
   | r >= 128 = rotateL128 w (r `mod` 128)
   | r == 64 = Word128 a0 a1
   | r > 64 = rotateL128 (Word128 a0 a1) (r `mod` 64)

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -332,7 +332,8 @@ complement128 (Word128 a1 a0) = Word128 (complement a1) (complement a0)
 shiftL128 :: Word128 -> Int -> Word128
 shiftL128 w@(Word128 a1 a0) s
   | s == 0 = w
-  | s < 0 = shiftL128 w (128 - (abs s `mod` 128))
+  | s == minBound = zeroWord128
+  | s < 0 = shiftR128 w (negate s)
   | s >= 128 = zeroWord128
   | s == 64 = Word128 a0 0
   | s > 64 = Word128 (a0 `shiftL` (s - 64)) 0
@@ -345,8 +346,9 @@ shiftL128 w@(Word128 a1 a0) s
 {-# INLINABLE shiftR128 #-}
 shiftR128 :: Word128 -> Int -> Word128
 shiftR128 w@(Word128 a1 a0) s
-  | s < 0 = zeroWord128
   | s == 0 = w
+  | s == minBound = zeroWord128
+  | s < 0 = shiftL128 w (negate s)
   | s >= 128 = zeroWord128
   | s == 64 = Word128 0 a1
   | s > 64 = Word128 0 (a1 `shiftR` (s - 64))

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -400,8 +400,10 @@ complement256 (Word256 a3 a2 a1 a0) =
 {-# INLINABLE shiftL256 #-}
 shiftL256 :: Word256 -> Int -> Word256
 shiftL256 w@(Word256 a3 a2 a1 a0) s
-  | s < 0 || s >= 256 = zeroWord256
   | s == 0 = w
+  | s == minBound = zeroWord256
+  | s < 0 = shiftR256 w (negate s)
+  | s >= 256 = zeroWord256
   | s > 192 = Word256 (a0 `shiftL` (s - 192)) 0 0 0
   | s == 192 = Word256 a0 0 0 0
   | s > 128 =
@@ -426,8 +428,9 @@ shiftL256 w@(Word256 a3 a2 a1 a0) s
 {-# INLINABLE shiftR256 #-}
 shiftR256 :: Word256 -> Int -> Word256
 shiftR256 w@(Word256 a3 a2 a1 a0) s
-  | s < 0 = zeroWord256
   | s == 0 = w
+  | s == minBound = zeroWord256
+  | s < 0 = shiftL256 w (negate s)
   | s >= 256 = zeroWord256
   | s > 192 = Word256 0 0 0 (a3 `shiftR` (s - 192))
   | s == 192 = Word256 0 0 0 a3

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -448,7 +448,7 @@ shiftR256 w@(Word256 a3 a2 a1 a0) s
 {-# INLINABLE rotateL256 #-}
 rotateL256 :: Word256 -> Int -> Word256
 rotateL256 w@(Word256 a3 a2 a1 a0) r
-  | r < 0 = zeroWord256
+  | r < 0 = rotateL256 w (256 - (abs r `mod` 256))
   | r == 0 = w
   | r >= 256 = rotateL256 w (r `mod` 256)
   | r >= 64 = rotateL256 (Word256 a2 a1 a0 a3) (r - 64)

--- a/test/Test/Data/WideWord/Word128.hs
+++ b/test/Test/Data/WideWord/Word128.hs
@@ -206,14 +206,12 @@ prop_logical_rotate_left =
     w128 <- H.forAll genWord128
     rot <- H.forAll $ Gen.int (Range.linearFrom 0 (-20000) 20000)
     let i128 = toInteger128 w128
-        expected
-          | rot < 0 = 0
-          | otherwise =
-              correctWord128 (i128 `shiftL` erot + i128 `shiftR` (128 - (erot `mod` 128)))
-              where
-                erot
-                  | rot < 0 = 128 - (abs rot `mod` 128)
-                  | otherwise = rot `mod` 128
+        expected =
+          correctWord128 $ i128 `shiftL` erot + i128 `shiftR` (128 - erot)
+          where
+            erot
+              | rot < 0 = 128 - (abs rot `mod` 128)
+              | otherwise = rot `mod` 128
     toInteger128 (rotateL w128 rot) === expected
 
 prop_logical_rotate_right :: Property


### PR DESCRIPTION
`rotateL x r` for `r < 0` should not be zero (if `x /= 0`) and `shiftL x s = shiftR x (negate s)` holds.