### PR TITLE
Allow hashable-1.5

### DIFF
--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -47,7 +47,7 @@ library
                      -- Required so that GHC.IntWord64 is available on 32 bit systems
                      , ghc-prim
                      , primitive                     >= 0.6.4.0     && < 0.10
-                     , hashable                      >= 1.2         && < 1.5
+                     , hashable                      >= 1.2         && < 1.6
 
 test-suite test
   default-language:   Haskell2010


### PR DESCRIPTION
The breaking change in hashable-1.5 doens't affect `wide-word`.