### PR TITLE
Reintroduce Data instances

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for wide-word
 
+## 0.1.8.1 -- 2025-??-??
+
+* Reintroduce Data instances.
+
 ## 0.1.8.0 -- 2025-09-08
 
 * Fix bug in Word256 implementions (minus).

--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
@@ -32,6 +32,7 @@ module Data.WideWord.Int128
 import Control.DeepSeq (NFData (..))
 
 import Data.Bits (Bits (..), FiniteBits (..), shiftL)
+import Data.Data (Data, Typeable)
 import Data.Ix (Ix)
 #if ! MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
@@ -68,7 +69,7 @@ data Int128 = Int128
   { int128Hi64 :: !Word64
   , int128Lo64 :: !Word64
   }
-  deriving (Eq, Generic, Ix)
+  deriving (Eq, Data, Generic, Ix)
 
 instance Hashable Int128 where
   hashWithSalt s (Int128 a1 a2) = s `hashWithSalt` a1 `hashWithSalt` a2

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE StrictData #-}
@@ -33,6 +34,7 @@ module Data.WideWord.Word128
 import Control.DeepSeq (NFData (..))
 
 import Data.Bits (Bits (..), FiniteBits (..), shiftL)
+import Data.Data (Data)
 import Data.Ix (Ix)
 #if ! MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
@@ -60,7 +62,7 @@ data Word128 = Word128
   { word128Hi64 :: !Word64
   , word128Lo64 :: !Word64
   }
-  deriving (Eq, Generic, Ix)
+  deriving (Eq, Data, Generic, Ix)
 
 instance Hashable Word128 where
   hashWithSalt s (Word128 a1 a2) = s `hashWithSalt` a1 `hashWithSalt` a2

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE StrictData #-}
@@ -30,6 +31,7 @@ module Data.WideWord.Word256
 import Control.DeepSeq (NFData (..))
 
 import Data.Bits (Bits (..), FiniteBits (..), shiftL)
+import Data.Data (Data)
 import Data.Ix (Ix)
 #if ! MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
@@ -61,7 +63,7 @@ data Word256 = Word256
   , word256m0 :: !Word64
   , word256lo :: !Word64
   }
-  deriving (Eq, Generic, Ix)
+  deriving (Eq, Data, Generic, Ix)
 
 instance Hashable Word256 where
   hashWithSalt s (Word256 a1 a2 a3 a4) =

--- a/wide-word.cabal
+++ b/wide-word.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                wide-word
-version:             0.1.8.0
+version:             0.1.8.1
 synopsis:            Data types for large but fixed width signed and unsigned integers
 description:
   A library to provide data types for large (ie > 64 bits) but fixed width signed


### PR DESCRIPTION
I think we should remove only the `Typeable` derivation (not required anymore), but we should continue to derive the `Data` instance, otherwise we would be forced to allow orphan instances for the datatypes of this library [1].

In case you are going to make a new release, I would also deprecated the current one.

[1] https://github.com/byteverse/haskell-ip/issues/91