### PR TITLE
Check WORDS_BIGENDIAN properly

### DIFF
--- a/.github/workflows/emulated.yml
+++ b/.github/workflows/emulated.yml
@@ -1,0 +1,43 @@
+name: emulated
+on:
+  - push
+  - pull_request
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Emulation is incredibly slow and memory demanding. It seems that any
+  # executable with GHC RTS takes at least 7-8 Gb of RAM, so we can run
+  # `cabal` or `ghc` on their own, but cannot run them both at the same time,
+  # striking out `cabal test`. Instead we rely on system packages and invoke
+  # `ghc --make` manually, and even so `ghc -O` is prohibitively expensive.
+  emulated:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: ['s390x']
+    steps:
+    - uses: actions/checkout@v4
+    - uses: uraimo/run-on-arch-action@v3
+      timeout-minutes: 60
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ubuntu_rolling
+        githubToken: ${{ github.token }}
+        install: |
+          apt-get update -y
+          apt-get install -y ghc libghc-hedgehog-dev libghc-quickcheck-classes-dev
+        run: |
+          export LANG=C.UTF-8
+          ghc --version
+          ghc --make -XGHC2021 -isrc:test -o test64 test/test64.hs +RTS -s
+          ./test64 +RTS -s
+          ghc --make -XGHC2021 -isrc:test -o test128 test/test128.hs +RTS -s
+          ./test128 +RTS -s
+          ghc --make -XGHC2021 -isrc:test -o test256 test/test256.hs +RTS -s
+          ./test256 +RTS -s
+          ghc --make -XGHC2021 -isrc:test -o laws test/laws.hs +RTS -s
+          ./laws +RTS -s

--- a/src/Data/WideWord/Int128.hs
+++ b/src/Data/WideWord/Int128.hs
@@ -22,6 +22,8 @@
 ---- "modulo 2^128" result as one would expect from a fixed width unsigned word.
 -------------------------------------------------------------------------------
 
+#include <MachDeps.h>
+
 module Data.WideWord.Int128
   ( Int128 (..)
   , byteSwapInt128
@@ -591,7 +593,7 @@ unInt :: Int -> Int#
 unInt (I# i#) = i#
 
 index0, index1 :: Int
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 index0 = 1
 index1 = 0
 #else

--- a/src/Data/WideWord/Word128.hs
+++ b/src/Data/WideWord/Word128.hs
@@ -589,7 +589,7 @@ unInt (I# i#) = i#
 
 -- Use these indices to get the peek/poke ordering endian correct.
 index0, index1 :: Int
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 index0 = 1
 index1 = 0
 #else

--- a/src/Data/WideWord/Word256.hs
+++ b/src/Data/WideWord/Word256.hs
@@ -22,6 +22,8 @@
 ---- "modulo 2^256" result as one would expect from a fixed width unsigned word.
 -------------------------------------------------------------------------------
 
+#include <MachDeps.h>
+
 module Data.WideWord.Word256
   ( Word256 (..)
   , showHexWord256
@@ -660,7 +662,7 @@ unInt (I# i#) = i#
 
 -- Use these indices to get the peek/poke ordering endian correct.
 index0, index1, index2, index3 :: Int
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 index0 = 3
 index1 = 2
 index2 = 1


### PR DESCRIPTION
* One should `#include <MachDeps.h>` before checking for `WORDS_BIGENDIAN`. Some modules already do it, some don't.
* One should check `#ifdef WORDS_BIGENDIAN`, not `#if WORDS_BIGENDIAN`. See how `bytestring` does it, for example.